### PR TITLE
Change: copy of dist files to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN npm run build:prod
 # Stage 2
 FROM nginx:1.22.0-alpine
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
-COPY --from=build-step /app/dist /usr/share/nginx/html
+COPY --from=build-step /app/dist/frontend-beavergoose /usr/share/nginx/html
 EXPOSE 80


### PR DESCRIPTION
* The previous version copied an entire folder & not replacing the
default nginx webpage.
* Now the correct folder are specified for copying files to the Docker
image.